### PR TITLE
Change MySQL DB from hard-coded port to configurable port

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -92,6 +92,9 @@ module.exports = {
     // MySQL host.
     host: 'localhost',
 
+    // MySQL port. (default uses 3306)
+    port: '3306',
+
     // MySQL username.
     username: 'user',
 

--- a/logic/database.js
+++ b/logic/database.js
@@ -21,7 +21,7 @@ exports.init = function() {
     {
       dialect: 'mysql',
       host: config.db.host,
-      port: 3306,
+      port: config.db.port,
       logging: winston.debug,
       define: {
         charset: 'utf8',


### PR DESCRIPTION
This makes it easier for someone using a PaaS with a database so they can use a non-default port without hard-coding the value.
